### PR TITLE
Add languages label to Docker images config

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -16,31 +16,37 @@ jobs:
           # Base image (Node + Python only)
           - repo: dev-base
             tag: "1"
+            languages: ""
           # Go
           - repo: dev-go
             tag: "1.23"
             go: "true"
             go_version: "1.23.4"
+            languages: "go,golang"
           # Rust
           - repo: dev-rust
             tag: "1.83"
             rust: "true"
             rust_version: "1.83.0"
+            languages: "rust"
           # Java
           - repo: dev-java
             tag: "21"
             java: "true"
             java_version: "21"
+            languages: "java"
           # .NET
           - repo: dev-dotnet
             tag: "8.0"
             dotnet: "true"
             dotnet_version: "8.0"
+            languages: "dotnet,csharp,fsharp,visualbasic"
           # Ruby
           - repo: dev-ruby
             tag: "3.3"
             ruby: "true"
             ruby_version: "3.3"
+            languages: "ruby"
 
     steps:
       - uses: actions/checkout@v4
@@ -73,5 +79,6 @@ jobs:
             JAVA_VERSION=${{ matrix.java_version || '21' }}
             DOTNET_VERSION=${{ matrix.dotnet_version || '8.0' }}
             RUBY_VERSION=${{ matrix.ruby_version || '3.3' }}
+            LANGUAGES=${{ matrix.languages || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ARG INSTALL_GO=false
 ARG INSTALL_JAVA=false
 ARG INSTALL_DOTNET=false
 ARG INSTALL_RUBY=false
+ARG LANGUAGES=""
 
 # Base dependencies
 RUN apt-get update && apt-get install -y \
@@ -108,3 +109,5 @@ RUN if [ "$INSTALL_RUBY" = "true" ]; then \
       ruby --version && \
       bundler --version ; \
     fi
+
+LABEL languages="${LANGUAGES}"


### PR DESCRIPTION
Add `languages` label to all the images. This allows us to query the Docker registry for the label for an image, which we will use for suggesting an image based on provided repos input. Having the label allows us to avoid hardcoding a mapping of images to languages on the backend.

Built one of the images and verified the label is present:
```
docker build -t warpdotdev/dev-go:1.23 --build-arg INSTALL_GO=true --build-arg GO_VERSION=1.23.4 --build-arg LANGUAGES=go,golang .
docker image inspect warpdotdev/dev-go:1.23 --format '{{ index .Config.Labels "languages" }}'
```