### PR TITLE
Update workflow to take in inputs for single image build

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -54,6 +54,12 @@ jobs:
             rust: "true"
             rust_version: "1.83.0"
             languages: "rust"
+          - repo: dev-rust
+            key: rust
+            tag: "1.85"
+            rust: "true"
+            rust_version: "1.85.0"
+            languages: "rust"
           # Java
           - repo: dev-java
             key: java


### PR DESCRIPTION
## Description
Updated the workflow so we can manually rerun the build and publish process for specific languages with specific versions. This is useful if, say, we want to release a version of the `dev-rust` image with Rust version 1.85.0.

## Testing
Used the workflow to release a version of the `dev-rust` image with Rust 1.85.0!