### PR TITLE
Use `latest` tag for dev-base and dev-web images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -40,7 +40,7 @@ jobs:
           # Base image (Node + Python only)
           - repo: dev-base
             key: base
-            tag: "1"
+            tag: "latest"
             languages: "python,javascript"
           # Go
           - repo: dev-go
@@ -86,7 +86,7 @@ jobs:
           # Web (browsers + Node + Python)
           - repo: dev-web
             key: web
-            tag: "1"
+            tag: "latest"
             browsers: "true"
             languages: "html,css,javascript"
           # Full image with all languages

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ warp integration create slack --environment env_abc123
 All images are based on Ubuntu. Language-specific images extend the base image with additional
 runtimes.
 
-- **warpdotdev/dev-base:1** — Node 22 + Python 3
+- **warpdotdev/dev-base:latest** — Node 22 + Python 3
 - **warpdotdev/dev-go:1.23** — Go 1.23.4 + base
 - **warpdotdev/dev-rust:1.83** — Rust 1.83.0 + base
 - **warpdotdev/dev-java:21** — Temurin JDK 21, Maven, Gradle + base
 - **warpdotdev/dev-dotnet:8.0** — .NET SDK 8.0 + base
 - **warpdotdev/dev-ruby:3.3** — Ruby 3.3 + Bundler + base
-- **warpdotdev/dev-web:1** — Google Chrome, Firefox + base
+- **warpdotdev/dev-web:latest** — Google Chrome, Firefox + base
 
 ## Helpful Tips
 


### PR DESCRIPTION
I noticed while testing the webapp that `pickWarpDevImage` falls back to `dev-base:latest` if it can't find a suitable image. **We don't currently have a latest tag for the dev-base image**, so requests fail when we try to use this suggested image.

I chose to switch to `latest` being the default tag from the workflow only for `dev-base` and `dev-web` because those are images we control. I figured it would be misleading to do this for the others, since `latest` has a different connotation when used with language-specific images (i.e. a user would expect the latest version of the language). 

We probably want to tidy up the logic in `pickWarpDevImage` too (it seems to try to use `latest` a lot, even though we don't support that for the language-specific images) but this should fix our original problem of recommending an image that doesn't exist. 