### PR TITLE
Bump the node version for the base image

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -10,6 +10,7 @@ on:
         options:
           - ''
           - base
+          - node
           - go
           - rust
           - java
@@ -42,6 +43,12 @@ jobs:
             key: base
             tag: "latest"
             languages: "python,javascript"
+          # Node (Node + Python)
+          - repo: dev-node
+            key: node
+            tag: "22"
+            node_version: "22.0.0"
+            languages: "javascript,python"
           # Go
           - repo: dev-go
             key: go
@@ -136,6 +143,7 @@ jobs:
             INSTALL_DOTNET=${{ matrix.dotnet || 'false' }}
             INSTALL_RUBY=${{ matrix.ruby || 'false' }}
             INSTALL_BROWSERS=${{ matrix.browsers || 'false' }}
+            NODE_VERSION=${{ matrix.key == 'node' && inputs.version || matrix.node_version || '24.0.0' }}
             GO_VERSION=${{ matrix.key == 'go' && inputs.version || matrix.go_version || '1.23.4' }}
             RUST_VERSION=${{ matrix.key == 'rust' && inputs.version || matrix.rust_version || '1.85.0' }}
             JAVA_VERSION=${{ matrix.key == 'java' && inputs.version || matrix.java_version || '21' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:latest
 # =============================================================================
 # VERSION CONFIGURATION
 # =============================================================================
-ARG NODE_VERSION=22.0.0
+ARG NODE_VERSION=24.0.0
 ARG GO_VERSION=1.23.4
 ARG RUST_VERSION=1.83.0
 ARG JAVA_VERSION=21


### PR DESCRIPTION
Bump the node version for the base image to 24.0.0, and add a separate `dev-node` image so we can still support node 22.

We keep Python in the `dev-node` image in case we need it for MCP in the environment, and because the `/create-environment` prompt expects that all of our dev images have both node and Python installed.