### PR TITLE
Add linux/arm64 support for all images except dev-web

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -42,12 +42,14 @@ jobs:
           - repo: dev-base
             key: base
             tag: "latest"
+            platforms: "linux/amd64,linux/arm64"
             languages: "python,javascript"
           # Node (Node + Python)
           - repo: dev-node
             key: node
             tag: "22"
             node_version: "22.0.0"
+            platforms: "linux/amd64,linux/arm64"
             languages: "javascript,python"
           # Go
           - repo: dev-go
@@ -55,6 +57,7 @@ jobs:
             tag: "1.23"
             go: "true"
             go_version: "1.23.4"
+            platforms: "linux/amd64,linux/arm64"
             languages: "go,golang"
           # Rust
           - repo: dev-rust
@@ -62,12 +65,14 @@ jobs:
             tag: "1.83"
             rust: "true"
             rust_version: "1.83.0"
+            platforms: "linux/amd64,linux/arm64"
             languages: "rust"
           - repo: dev-rust
             key: rust
             tag: "1.85"
             rust: "true"
             rust_version: "1.85.0"
+            platforms: "linux/amd64,linux/arm64"
             languages: "rust"
           # Java
           - repo: dev-java
@@ -75,6 +80,7 @@ jobs:
             tag: "21"
             java: "true"
             java_version: "21"
+            platforms: "linux/amd64,linux/arm64"
             languages: "java"
           # .NET
           - repo: dev-dotnet
@@ -82,6 +88,7 @@ jobs:
             tag: "8.0"
             dotnet: "true"
             dotnet_version: "8.0"
+            platforms: "linux/amd64,linux/arm64"
             languages: "dotnet,csharp,fsharp,visualbasic"
           # Ruby
           - repo: dev-ruby
@@ -89,12 +96,14 @@ jobs:
             tag: "3.3"
             ruby: "true"
             ruby_version: "3.3"
+            platforms: "linux/amd64,linux/arm64"
             languages: "ruby"
-          # Web (browsers + Node + Python)
+          # Web (browsers - amd64 only, Chrome/Firefox packages are x86_64)
           - repo: dev-web
             key: web
             tag: "latest"
             browsers: "true"
+            platforms: "linux/amd64"
             languages: "html,css,javascript"
           # Full image with all languages
           - repo: dev-full
@@ -110,11 +119,16 @@ jobs:
             dotnet_version: "8.0"
             ruby: "true"
             ruby_version: "3.3"
+            platforms: "linux/amd64,linux/arm64"
             languages: "go,golang,rust,java,dotnet,csharp,fsharp,visualbasic,ruby,python,javascript"
 
     steps:
       - uses: actions/checkout@v4
         if: ${{ inputs.image == '' || inputs.image == matrix.key }}
+
+      - name: Set up QEMU
+        if: ${{ inputs.image == '' || inputs.image == matrix.key }}
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         if: ${{ inputs.image == '' || inputs.image == matrix.key }}
@@ -134,7 +148,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: ${{ matrix.platforms }}
           tags: warpdotdev/${{ matrix.repo }}:${{ inputs.tag || matrix.tag }}
           build-args: |
             INSTALL_RUST=${{ matrix.rust || 'false' }}
@@ -161,7 +175,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: ${{ matrix.platforms }}
           tags: warpdotdev/${{ matrix.repo }}:${{ inputs.tag || matrix.tag }}-agents
           build-args: |
             INSTALL_RUST=${{ matrix.rust || 'false' }}


### PR DESCRIPTION
## Description

Self-hosted workers running on arm64 hosts (e.g., Apple Silicon Macs) fail with:
```
Task launch failed: failed to create container: Error response from daemon: No such image: warpdotdev/<iage>
```
All images are currently built for `linux/amd64` only, so arm64 hosts can't pull a usable image.

This adds `arm` versions for all of the supported images except for `dev-web`. The Dockerfile already handles architecture detection for Node, Go, .NET, etc. via `dpkg --print-architecture` (except for `dev-web`, which we limit to just `amd`). 

This is a short-term fix, we also need to validate better both for self-hosted and Namespace workers that we have the right architecture available for images (cc @acarl005 who mentioned that we may want to change how we enforce arch type for self hosted).

## Testing
Ran the workflow and generated images.

_This PR was generated with [Warp](https://www.warp.dev/)._
