### PR TITLE
Set up Docker image attestations

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   build-matrix:
     name: ${{ matrix.repo }}:${{ inputs.image == matrix.key && inputs.tag || matrix.tag }}
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-ubuntu-small
     strategy:
       fail-fast: false
       matrix:
@@ -126,14 +126,6 @@ jobs:
       - uses: actions/checkout@v4
         if: ${{ inputs.image == '' || inputs.image == matrix.key }}
 
-      - name: Set up QEMU
-        if: ${{ inputs.image == '' || inputs.image == matrix.key }}
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        if: ${{ inputs.image == '' || inputs.image == matrix.key }}
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to DockerHub
         if: ${{ inputs.image == '' || inputs.image == matrix.key }}
         uses: docker/login-action@v3
@@ -147,6 +139,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          sbom: true
+          provenance: mode=max
           push: true
           platforms: ${{ matrix.platforms }}
           tags: warpdotdev/${{ matrix.repo }}:${{ inputs.tag || matrix.tag }}
@@ -165,8 +159,6 @@ jobs:
             DOTNET_VERSION=${{ matrix.key == 'dotnet' && inputs.version || matrix.dotnet_version || '8.0' }}
             RUBY_VERSION=${{ matrix.key == 'ruby' && inputs.version || matrix.ruby_version || '3.3' }}
             LANGUAGES=${{ matrix.languages || '' }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Build and push (agents variant)
         if: ${{ inputs.image == '' || inputs.image == matrix.key }}
@@ -174,6 +166,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          sbom: true
+          provenance: mode=max
           push: true
           platforms: ${{ matrix.platforms }}
           tags: warpdotdev/${{ matrix.repo }}:${{ inputs.tag || matrix.tag }}-agents
@@ -192,5 +186,3 @@ jobs:
             DOTNET_VERSION=${{ matrix.key == 'dotnet' && inputs.version || matrix.dotnet_version || '8.0' }}
             RUBY_VERSION=${{ matrix.key == 'ruby' && inputs.version || matrix.ruby_version || '3.3' }}
             LANGUAGES=${{ matrix.languages || '' }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
Docker's GitHub actions support a few kinds of [attestations](https://docs.docker.com/build/ci/github-actions/attestations/) for:
* Proving that an image was built by Warp
* Documenting the expected software in an image

This is pretty easy to enable, so I think we should do so for our dev base images.

I'm also switching the action to run on Namespace, which should speed things up.
