### PR TITLE
Add a dev-bun image

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -10,6 +10,7 @@ on:
         options:
           - ''
           - base
+          - bun
           - node
           - go
           - rust
@@ -43,6 +44,13 @@ jobs:
             key: base
             tag: "latest"
             languages: "python,javascript"
+          # Bun
+          - repo: dev-bun
+            key: bun
+            tag: "1.3"
+            bun: "true"
+            bun_version: "1.3.9"
+            languages: ""
           # Node (Node + Python)
           - repo: dev-node
             key: node
@@ -100,6 +108,8 @@ jobs:
           - repo: dev-full
             key: full
             tag: "latest"
+            bun: "true"
+            bun_version: "1.3.9"
             go: "true"
             go_version: "1.23.4"
             rust: "true"
@@ -137,6 +147,7 @@ jobs:
           platforms: linux/amd64
           tags: warpdotdev/${{ matrix.repo }}:${{ inputs.tag || matrix.tag }}
           build-args: |
+            INSTALL_BUN=${{ matrix.bun || 'false' }}
             INSTALL_RUST=${{ matrix.rust || 'false' }}
             INSTALL_GO=${{ matrix.go || 'false' }}
             INSTALL_JAVA=${{ matrix.java || 'false' }}
@@ -144,6 +155,7 @@ jobs:
             INSTALL_RUBY=${{ matrix.ruby || 'false' }}
             INSTALL_BROWSERS=${{ matrix.browsers || 'false' }}
             INSTALL_CODING_AGENTS=false
+            BUN_VERSION=${{ matrix.key == 'bun' && inputs.version || matrix.bun_version || '1.3.9' }}
             NODE_VERSION=${{ matrix.key == 'node' && inputs.version || matrix.node_version || '24.0.0' }}
             GO_VERSION=${{ matrix.key == 'go' && inputs.version || matrix.go_version || '1.23.4' }}
             RUST_VERSION=${{ matrix.key == 'rust' && inputs.version || matrix.rust_version || '1.85.0' }}
@@ -164,6 +176,7 @@ jobs:
           platforms: linux/amd64
           tags: warpdotdev/${{ matrix.repo }}:${{ inputs.tag || matrix.tag }}-agents
           build-args: |
+            INSTALL_BUN=${{ matrix.bun || 'false' }}
             INSTALL_RUST=${{ matrix.rust || 'false' }}
             INSTALL_GO=${{ matrix.go || 'false' }}
             INSTALL_JAVA=${{ matrix.java || 'false' }}
@@ -171,6 +184,7 @@ jobs:
             INSTALL_RUBY=${{ matrix.ruby || 'false' }}
             INSTALL_BROWSERS=${{ matrix.browsers || 'false' }}
             INSTALL_CODING_AGENTS=true
+            BUN_VERSION=${{ matrix.key == 'bun' && inputs.version || matrix.bun_version || '1.3.9' }}
             NODE_VERSION=${{ matrix.key == 'node' && inputs.version || matrix.node_version || '24.0.0' }}
             GO_VERSION=${{ matrix.key == 'go' && inputs.version || matrix.go_version || '1.23.4' }}
             RUST_VERSION=${{ matrix.key == 'rust' && inputs.version || matrix.rust_version || '1.85.0' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:latest
 # VERSION CONFIGURATION
 # =============================================================================
 ARG NODE_VERSION=24.0.0
+ARG BUN_VERSION=1.3.9
 ARG GO_VERSION=1.23.4
 ARG RUST_VERSION=1.83.0
 ARG JAVA_VERSION=21
@@ -13,6 +14,7 @@ ARG RUBY_VERSION=3.3
 # =============================================================================
 # INSTALL FLAGS
 # =============================================================================
+ARG INSTALL_BUN=false
 ARG INSTALL_RUST=false
 ARG INSTALL_GO=false
 ARG INSTALL_JAVA=false
@@ -49,6 +51,23 @@ RUN apt-get update && apt-get install -y \
     ln -sf /usr/bin/python3 /usr/bin/python && \
     rm -rf /var/lib/apt/lists/* && \
     python --version
+
+# Bun
+RUN if [ "$INSTALL_BUN" = "true" ]; then \
+      apt-get update && apt-get install -y unzip && \
+      rm -rf /var/lib/apt/lists/* && \
+      dpkgArch="$(dpkg --print-architecture)"; \
+      case "${dpkgArch##*-}" in \
+        amd64) ARCH='x64';; \
+        arm64) ARCH='aarch64';; \
+      esac; \
+      curl --proto '=https' --tlsv1.2 -fsSLO "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-$ARCH.zip" && \
+      unzip bun-linux-$ARCH.zip -d /tmp/bun && \
+      mv /tmp/bun/bun-linux-$ARCH/bun /usr/local/bin/bun && \
+      chmod +x /usr/local/bin/bun && \
+      rm -rf bun-linux-$ARCH.zip /tmp/bun && \
+      bun --version ; \
+    fi
 
 # Rust
 RUN if [ "$INSTALL_RUST" = "true" ]; then \

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ runtimes. Each image is published in two variants:
 | Image | Tag | Contents |
 |-------|-----|----------|
 | **warpdotdev/dev-base** | `latest` / `latest-agents` | Node 22 + Python 3 |
+| **warpdotdev/dev-bun** | `1.3` / `1.3-agents` | Bun 1.3.9 + base |
 | **warpdotdev/dev-go** | `1.23` / `1.23-agents` | Go 1.23.4 + base |
 | **warpdotdev/dev-rust** | `1.83` / `1.83-agents` | Rust 1.83.0 + base |
 | **warpdotdev/dev-rust** | `1.85` / `1.85-agents` | Rust 1.85.0 + base |


### PR DESCRIPTION
## Description

Add a `dev-bun` image that contains Bun as well as the base dev tools (Addresses https://github.com/warpdotdev/oz-dev-environments/issues/11). 

We do not add language tags to the image so it isn't suggested by our auto-suggest Docker image flow (we don't want to suggest Bun automatically for any js project; the `dev-base` image is still better for that general case).

## Testing

Built and pushed a `dev-bun` image and confirmed that an Oz agent using this environment can run Bun.