### PR TITLE
Build images on push to main

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,6 +1,9 @@
 name: Build and Push Dev Images
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       image:


### PR DESCRIPTION
This PR updates the `build-images.yml` workflow so that in addition to being able to build the docker images manually, we automatically rebuild all of the images when we push to main. This should stop us forgetting to run the workflow after making a change!