### PR TITLE
Add `uv` to dev images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,10 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/* && \
     python --version
 
+# uv + uvx (Python package/project manager)
+RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh && \
+    uv --version
+
 # Bun
 RUN if [ "$INSTALL_BUN" = "true" ]; then \
       apt-get update && apt-get install -y unzip && \


### PR DESCRIPTION
## Description
This PR adds `uv` to dev images, as it's often used in MCP servers ([Orchestra](https://github.com/orchestra-hq/orchestra-mcp), [Google Collab](https://github.com/googlecolab/colab-mcp))

The binary adds about 70MB to the image, but doesn't meaningfully increase the image size (it's already over a GB)—seems like a worthy change to make to support more MCP servers out of the box. 