### PR TITLE
Add arm support for the dev-web image.

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -109,12 +109,12 @@ jobs:
             ruby_version: "3.3"
             platforms: "linux/amd64,linux/arm64"
             languages: "ruby"
-          # Web (browsers - amd64 only, Chrome/Firefox packages are x86_64)
+          # Web (browsers)
           - repo: dev-web
             key: web
             tag: "latest"
             browsers: "true"
-            platforms: "linux/amd64"
+            platforms: "linux/amd64,linux/arm64"
             languages: "html,css,javascript"
           # Full image with all languages
           - repo: dev-full

--- a/Dockerfile
+++ b/Dockerfile
@@ -131,22 +131,37 @@ RUN if [ "$INSTALL_RUBY" = "true" ]; then \
       bundler --version ; \
     fi
 
-# Browsers (Google Chrome + Firefox)
+# Browsers (Chrome/Chromium + Firefox)
 RUN if [ "$INSTALL_BROWSERS" = "true" ]; then \
       apt-get update && apt-get install -y \
         wget \
         libdbus-glib-1-2 && \
-      # Install Google Chrome from upstream
-      wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-      apt-get install -y ./google-chrome-stable_current_amd64.deb && \
-      rm google-chrome-stable_current_amd64.deb && \
+      dpkgArch="$(dpkg --print-architecture)"; \
+      if [ "$dpkgArch" = "amd64" ]; then \
+        # Install Google Chrome (amd64 only)
+        wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+        apt-get install -y ./google-chrome-stable_current_amd64.deb && \
+        rm google-chrome-stable_current_amd64.deb ; \
+      else \
+        # Install Chromium from Debian repos on non-amd64
+        wget -qO- https://ftp-master.debian.org/keys/release-12.asc | gpg --dearmor -o /usr/share/keyrings/debian-bookworm.gpg && \
+        echo "deb [signed-by=/usr/share/keyrings/debian-bookworm.gpg] http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/debian-bookworm.list && \
+        printf 'Package: *\nPin: origin deb.debian.org\nPin-Priority: 1\n\nPackage: chromium chromium-common\nPin: origin deb.debian.org\nPin-Priority: 500\n' > /etc/apt/preferences.d/chromium && \
+        apt-get update && \
+        apt-get install -y --no-install-recommends chromium && \
+        ln -sf /usr/bin/chromium /usr/local/bin/google-chrome ; \
+      fi && \
       # Install Firefox from Mozilla
-      wget -q -O firefox.tar.xz "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US" && \
+      case "$dpkgArch" in \
+        amd64) FF_OS='linux64';; \
+        arm64) FF_OS='linux64-aarch64';; \
+      esac && \
+      wget -q -O firefox.tar.xz "https://download.mozilla.org/?product=firefox-latest&os=$FF_OS&lang=en-US" && \
       tar -xf firefox.tar.xz -C /opt && \
       ln -s /opt/firefox/firefox /usr/local/bin/firefox && \
       rm firefox.tar.xz && \
       rm -rf /var/lib/apt/lists/* && \
-      echo "Chrome version:" && google-chrome --version && \
+      echo "Chrome/Chromium version:" && google-chrome --version && \
       echo "Firefox version:" && firefox --version ; \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM debian:bookworm-slim
 
 # =============================================================================
 # VERSION CONFIGURATION
@@ -131,27 +131,14 @@ RUN if [ "$INSTALL_RUBY" = "true" ]; then \
       bundler --version ; \
     fi
 
-# Browsers (Chrome/Chromium + Firefox)
+# Browsers (Chromium + Firefox)
 RUN if [ "$INSTALL_BROWSERS" = "true" ]; then \
       apt-get update && apt-get install -y \
         wget \
-        libdbus-glib-1-2 && \
+        libdbus-glib-1-2 \
+        --no-install-recommends chromium && \
+      ln -sf /usr/bin/chromium /usr/local/bin/google-chrome && \
       dpkgArch="$(dpkg --print-architecture)"; \
-      if [ "$dpkgArch" = "amd64" ]; then \
-        # Install Google Chrome (amd64 only)
-        wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-        apt-get install -y ./google-chrome-stable_current_amd64.deb && \
-        rm google-chrome-stable_current_amd64.deb ; \
-      else \
-        # Install Chromium from Debian repos on non-amd64
-        wget -qO- https://ftp-master.debian.org/keys/release-12.asc | gpg --dearmor -o /usr/share/keyrings/debian-bookworm.gpg && \
-        echo "deb [signed-by=/usr/share/keyrings/debian-bookworm.gpg] http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/debian-bookworm.list && \
-        printf 'Package: *\nPin: origin deb.debian.org\nPin-Priority: 1\n\nPackage: chromium chromium-common\nPin: origin deb.debian.org\nPin-Priority: 500\n' > /etc/apt/preferences.d/chromium && \
-        apt-get update && \
-        apt-get install -y --no-install-recommends chromium && \
-        ln -sf /usr/bin/chromium /usr/local/bin/google-chrome ; \
-      fi && \
-      # Install Firefox from Mozilla
       case "$dpkgArch" in \
         amd64) FF_OS='linux64';; \
         arm64) FF_OS='linux64-aarch64';; \
@@ -161,7 +148,7 @@ RUN if [ "$INSTALL_BROWSERS" = "true" ]; then \
       ln -s /opt/firefox/firefox /usr/local/bin/firefox && \
       rm firefox.tar.xz && \
       rm -rf /var/lib/apt/lists/* && \
-      echo "Chrome/Chromium version:" && google-chrome --version && \
+      echo "Chromium version:" && chromium --version && \
       echo "Firefox version:" && firefox --version ; \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 # =============================================================================
 # VERSION CONFIGURATION

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ oz agent run-cloud \
 
 ## Available images
 
-All images are based on Ubuntu. Language-specific images extend the base image with additional
+All images are based on Debian. Language-specific images extend the base image with additional
 runtimes. Each image is published in two variants:
 
 - **Base** (e.g. `warpdotdev/dev-rust:1.85`) — language runtimes and core tools only


### PR DESCRIPTION
## Description

This PR adds arm64 support for the `dev-web` base image. 

There currently isn't native support for running Chrome on arm Linux ([but there will be soon](https://www.techrepublic.com/article/news-google-chrome-arm64-linux-support-2026/)), so we install Chromium instead. Practically, this should be the same for the purposes of testing web changes in the environment.

We also switch the base image from ubuntu to debian, since debian ships with chromium easily installable as a `.deb` package. Ubuntu ships chromium as a snap package, which is problematic for Docker. 

The base images are comparable size (locally, `ubuntu:latest` is 139MB and `debian:trixie-slim` is also 139MB), and this switch shouldn't break any of the existing configuration.

## Testing

Built the image locally and confirmed that the installs run, and chromium can be used.
